### PR TITLE
3: Approve limited number of ERC20s rather than infinite

### DIFF
--- a/frontend/src/components/Pages/YTC/Calculator/ApproveAndSimulateButton.tsx
+++ b/frontend/src/components/Pages/YTC/Calculator/ApproveAndSimulateButton.tsx
@@ -9,14 +9,15 @@ interface ApproveAndSimulateButtonProps {
     tokenAddress: string | undefined;
     tokenName: string | undefined;
     trancheAddress: string | undefined;
-    formErrors: {[fieldName: string]: string | undefined}
+    formErrors: {[fieldName: string]: string | undefined};
+    amount: number | undefined;
 }
 
 
 export const ApproveAndSimulateButton: React.FC<ApproveAndSimulateButtonProps & ButtonProps> = (props) => {
     const ytc = useContext(YieldTokenCompoundingContext);
 
-    const { tokenAddress, tokenName, trancheAddress, formErrors, ...rest} = props;
+    const { tokenAddress, tokenName, trancheAddress, formErrors, amount, ...rest} = props;
 
     return <BalancerApproval
         trancheAddress={trancheAddress}
@@ -26,6 +27,7 @@ export const ApproveAndSimulateButton: React.FC<ApproveAndSimulateButtonProps & 
             tokenAddress={tokenAddress}
             tokenName={tokenName}
             approvalAddress={ytc.instance?.address}
+            amount={amount}
             {...rest}
         >
             <SimulateButton 

--- a/frontend/src/components/Pages/YTC/Calculator/index.tsx
+++ b/frontend/src/components/Pages/YTC/Calculator/index.tsx
@@ -469,6 +469,7 @@ const Form: React.FC<FormProps> = (props) => {
             tokenAddress={formik.values.tokenAddress}
             tokenName={getTokenNameByAddress(formik.values.tokenAddress)}
             trancheAddress={formik.values.trancheAddress}
+            amount={formik.values.amount}
             rounded="full"
             bgColor="main.primary"
             color="text.secondary"


### PR DESCRIPTION
The user is able to give approval for the amount that they are simulating/YTCing, rather than infinite approval.