### PR TITLE
Add slippage protection for the number of base tokens that are spent

### DIFF
--- a/frontend/src/components/Pages/YTC/Executor/index.tsx
+++ b/frontend/src/components/Pages/YTC/Executor/index.tsx
@@ -60,6 +60,8 @@ export const Ape: React.FC<ApeProps> = (props: ApeProps) => {
             executeYieldTokenCompounding(
                 userData,
                 yieldTokenAmount,
+                // this is equivalent to base tokens spent
+                (inputAmount-baseTokenAmount),
                 slippageTolerance,
                 elementAddresses,
                 signer

--- a/frontend/src/features/ytc/executeYieldTokenCompounding.ts
+++ b/frontend/src/features/ytc/executeYieldTokenCompounding.ts
@@ -11,28 +11,51 @@ import { YieldTokenCompounding as YieldTokenCompoundingType } from "../../hardha
 // param elementAddresses, the constants object containing element deployment addresses
 // param signer, the signer of the transaction
 // Returns a transaction receipt
-export const executeYieldTokenCompounding = async (userData: YTCInput, expectedYieldTokens: number, slippageTolerancePercentage: number, elementAddresses: ElementAddresses, signer: Signer): Promise<ContractReceipt> => {
+export const executeYieldTokenCompounding = async (userData: YTCInput, expectedYieldTokens: number, expectedBaseTokensSpent: number, slippageTolerancePercentage: number, elementAddresses: ElementAddresses, signer: Signer): Promise<ContractReceipt> => {
     const yieldCalculationParameters = await getYTCParameters(userData, elementAddresses, signer);
 
     const expectedYieldTokensAbsolute = ethers.utils.parseUnits(expectedYieldTokens.toString(), yieldCalculationParameters.yieldTokenDecimals);
 
-    // The maximum number of yTokens that can be lost due to slippage
-    const maximumSlippageTokens = expectedYieldTokens * (slippageTolerancePercentage/100);
-
-    let maximumSlippageTokensAbsolute;
+    let expectedBaseTokensSpentAbsolute;
     try {
-        // If there are too many decimals parsing the units will fail, thus we cut it to 8 decimals
-        maximumSlippageTokensAbsolute = ethers.utils.parseUnits((maximumSlippageTokens).toString(), yieldCalculationParameters.yieldTokenDecimals);
+        // If there are too many decimals parsing the units will fail, thus we cut it to 6 decimals
+        expectedBaseTokensSpentAbsolute = ethers.utils.parseUnits(expectedBaseTokensSpent.toString(), yieldCalculationParameters.baseTokenDecimals);
     } catch {
-        maximumSlippageTokensAbsolute = ethers.utils.parseUnits((maximumSlippageTokens.toFixed(6)), yieldCalculationParameters.yieldTokenDecimals)
+        expectedBaseTokensSpentAbsolute = ethers.utils.parseUnits((expectedBaseTokensSpent.toFixed(6)), yieldCalculationParameters.baseTokenDecimals)
+    }
+
+    // The maximum number of yTokens that can be lost due to slippage
+    // This will be half the maximum slippage
+    const maximumSlippageYTokens = expectedYieldTokens * (slippageTolerancePercentage/2/100);
+
+    // The maximum number of base tokens that can be lost due to slippage
+    // This will be half the maximum slippage
+    const maximumSlippageBaseTokens = expectedBaseTokensSpent * (slippageTolerancePercentage/2/100);
+
+    let maximumSlippageYTokensAbsolute;
+    try {
+        // If there are too many decimals parsing the units will fail, thus we cut it to 6 decimals
+        maximumSlippageYTokensAbsolute = ethers.utils.parseUnits((maximumSlippageYTokens).toString(), yieldCalculationParameters.yieldTokenDecimals);
+    } catch {
+        maximumSlippageYTokensAbsolute = ethers.utils.parseUnits((maximumSlippageYTokens.toFixed(6)), yieldCalculationParameters.yieldTokenDecimals)
+    }
+    let maximumSlippageBaseTokensAbsolute;
+    try {
+        // If there are too many decimals parsing the units will fail, thus we cut it to 6 decimals
+        maximumSlippageBaseTokensAbsolute = ethers.utils.parseUnits((maximumSlippageBaseTokens).toString(), yieldCalculationParameters.baseTokenDecimals);
+    } catch {
+        maximumSlippageBaseTokensAbsolute = ethers.utils.parseUnits((maximumSlippageBaseTokens.toFixed(6)), yieldCalculationParameters.baseTokenDecimals)
     }
 
     // The minimum number of yTokens that should be received
-    const minimumYieldAbsolute = expectedYieldTokensAbsolute.sub(maximumSlippageTokensAbsolute);
+    const minimumYieldAbsolute = expectedYieldTokensAbsolute.sub(maximumSlippageYTokensAbsolute);
+    const maximumSpentAbsolute = expectedBaseTokensSpentAbsolute.add(maximumSlippageBaseTokensAbsolute);
+
+    console.log(maximumSpentAbsolute.toString());
 
     const ytc: YieldTokenCompoundingType = yieldCalculationParameters.ytc as YieldTokenCompoundingType;
 
-    const transaction = await ytc.compound(userData.numberOfCompounds, userData.trancheAddress, yieldCalculationParameters.balancerPoolId, yieldCalculationParameters.baseTokenAmountAbsolute, minimumYieldAbsolute);
+    const transaction = await ytc.compound(userData.numberOfCompounds, userData.trancheAddress, yieldCalculationParameters.balancerPoolId, yieldCalculationParameters.baseTokenAmountAbsolute, minimumYieldAbsolute, maximumSpentAbsolute);
 
     const transactionReceipt = await transaction.wait();
 

--- a/frontend/src/features/ytc/simulateYTC.ts
+++ b/frontend/src/features/ytc/simulateYTC.ts
@@ -4,6 +4,8 @@ import { GAS_LIMITS } from "../../constants/gasLimits";
 import { ElementAddresses } from "../../types/manual/types";
 import { getYTCParameters, YTCInput, YTCOutput, YTCParameters } from "./ytcHelpers";
 
+const MAX_UINT_HEX = '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
 // Simulates a single yield token compounding execution to determine what the output would be
 // No actual transaction is executed
 // param YTC Parameters, derived params required to execute the transaction, a ytc contract instance, the balancer pool, decimals for tokens, the name of the yield token etc.
@@ -12,7 +14,8 @@ import { getYTCParameters, YTCInput, YTCOutput, YTCParameters } from "./ytcHelpe
 // returns YTCOutput, contains both input data, and the results fo the simulation, including yield exposure, gas fees, tokens spent, remaining tokens etc.
 export const simulateYTC = async ({ytc, trancheAddress, trancheExpiration, balancerPoolId, yieldTokenDecimals, baseTokenDecimals, baseTokenName, ytSymbol: ytName, baseTokenAmountAbsolute, ethToBaseTokenRate}: YTCParameters, userData: YTCInput, signer: Signer): Promise<YTCOutput> => {
     // Call the method statically to calculate the estimated return
-    const returnedVals = await ytc.callStatic.compound(userData.numberOfCompounds, trancheAddress, balancerPoolId, baseTokenAmountAbsolute, "0");
+    // The last two arguments are to prevent slippage, but this isn't required as it is a simulation and cannot be frontrun
+    const returnedVals = await ytc.callStatic.compound(userData.numberOfCompounds, trancheAddress, balancerPoolId, baseTokenAmountAbsolute, "0", MAX_UINT_HEX);
 
     // Estimate the required amount of gas, this is likely very imprecise
     // const gasAmountEstimate = await ytc.estimateGas.compound(userData.numberOfCompounds, trancheAddress, balancerPoolId, baseTokenAmountAbsolute, "0");


### PR DESCRIPTION
Implemented as such:

Slippage tolerance will refer to the the movement of both the Yield Tokens Received and the Base Tokens Spent.

This means that 1% slippage will allow up to a 0.5% decrease in the number of YTs received, and 0.5% increase in the number of BTs spent.

This seems inelegant, but I'm not sure of the better way to do it.