### PR TITLE
Feature/great apr apy switchup

### DIFF
--- a/frontend/src/components/Pages/YTC/Executor/index.tsx
+++ b/frontend/src/components/Pages/YTC/Executor/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner, Flex, FormLabel, Icon, Text } from "@chakra-ui/react";
+import { Button, Spinner, Flex, FormLabel, Icon, Text, Tooltip } from "@chakra-ui/react";
 import { YTCGain, YTCInput } from "../../../../features/ytc/ytcHelpers";
 import { executeYieldTokenCompounding } from "../../../../features/ytc/executeYieldTokenCompounding";
 import { elementAddressesAtom } from "../../../../recoil/element/atom";
@@ -162,7 +162,7 @@ export const Ape: React.FC<ApeProps> = (props: ApeProps) => {
                         estimatedGas={gas.eth}
                         netGain= {gain?.netGain}
                         roi={gain?.roi}
-                        apy={gain?.apy}
+                        apr={gain?.apr}
                         minimumReceived={minimumReturn}
                         expectedReturn={gain?.estimatedRedemption}
                     />
@@ -194,11 +194,11 @@ interface ExecutionDetailsProps {
     estimatedGas: number,
     netGain?: number,
     roi?: number, 
-    apy?: number,
+    apr?: number,
 }
 
 const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
-    const {slippageTolerance, minimumReceived, estimatedGas, netGain, roi, apy, expectedReturn} = props;
+    const {slippageTolerance, minimumReceived, estimatedGas, netGain, roi, apr, expectedReturn} = props;
 
     return <DetailPane
         mx={10}
@@ -246,17 +246,23 @@ const ExecutionDetails: React.FC<ExecutionDetailsProps> = (props) => {
                 </Text> : "?"
             }
         />
-        <DetailItem
-            name="APY: "
-            value={apy ? 
-                <Text
-                    color={(apy > 0 ? "green.600" : "red.500")}
-                >
-                    {shortenNumber(apy)}%
-                </Text> : "?"
-            }
+        <Tooltip
+            label="Return on investment over the term annualized."
+        >
+            <div>
+                <DetailItem
+                    name="APR: "
+                    value={apr ? 
+                        <Text
+                            color={(apr > 0 ? "green.600" : "red.500")}
+                        >
+                            {shortenNumber(apr)}%
+                        </Text> : "?"
+                    }
 
-        />
+                />
+            </div>
+        </Tooltip>
     </DetailPane>
 }
 

--- a/frontend/src/components/Pages/YTC/Table/ResultsTableRow.tsx
+++ b/frontend/src/components/Pages/YTC/Table/ResultsTableRow.tsx
@@ -1,4 +1,4 @@
-import { Tr, Td } from "@chakra-ui/react";
+import { Tr, Td, Tooltip } from "@chakra-ui/react";
 import { YTCOutput } from "../../../../features/ytc/ytcHelpers";
 import { shortenNumber } from "../../../../utils/shortenNumber";
 import { BaseTokenPriceTag } from "../../../Prices";
@@ -21,8 +21,7 @@ export const ResultsTableRow: React.FC<ResultsTableRowInterface> = (props) => {
             color={isSelected ? "text.secondary" : "text.primary"}
             cursor="pointer"
             _hover={{
-                bgColor: isSelected ? "main.primary" : "main.primary_hover",
-                color: "text.secondary"
+                bgColor: isSelected ? "main.primary" : "blue.100",
             }}
         >
             <Td isNumeric>
@@ -39,15 +38,22 @@ export const ResultsTableRow: React.FC<ResultsTableRowInterface> = (props) => {
             <Td isNumeric
                 textColor={
                     output.gain ?
-                        (output.gain?.netGain >= 0) ? 
-                            "green.600" : 
-                            "red.500" :
+                        (output.gain.netGain >= 0) ? 
+                            (isSelected ? "green.200" : "green.600") : 
+                            (isSelected ? "red.200" : "red.500") :
                         "inherit"
                 }
             >
-                {output.gain ? <BaseTokenPriceTag amount={output.gain.netGain} baseTokenName={baseTokenName}/> : "?"}
+                {output.gain ? 
+                    <BaseTokenPriceTag amount={output.gain.netGain} baseTokenName={baseTokenName}/> :
+                    "?"
+                }
                 <br/>
-                {output.gain ? ` (%${shortenNumber(output.gain.apy)} APY)` : "?"}
+                <Tooltip
+                    label={`Return on investment over the term annualized. ${output.gain && shortenNumber(output.gain.roi)}% x ${output.gain && shortenNumber(output.gain.apr/output.gain.roi)}`}
+                >
+                    {output.gain ? ` (%${shortenNumber(output.gain.apr)} APR)` : "?"}
+                </Tooltip>
             </Td>
         </Tr>
     )

--- a/frontend/src/features/ytc/ytcHelpers.ts
+++ b/frontend/src/features/ytc/ytcHelpers.ts
@@ -25,7 +25,7 @@ export interface YTCGain {
     estimatedRedemption: number;
     netGain: number,
     roi: number,
-    apy: number,
+    apr: number,
 }
 
 export interface YTCOutput {
@@ -164,21 +164,21 @@ export const calculateGain = (ytExposure: number, speculatedVariableRate: number
 
 
     // speculated variable rate is an apy, but we need this as an apr
-    const returnPercentage = (1 + speculatedVariableRate/100)**termRemainingYears - 1;
+    const returnPercentage = speculatedVariableRate*termRemainingYears;
 
-    const returnedTokens = (returnPercentage + yieldTokenAccruedValue) * ytExposure;
+    const returnedTokens = (returnPercentage/100 + yieldTokenAccruedValue) * ytExposure;
 
 
     const netGain = (returnedTokens) - baseTokensSpent - estimatedBaseTokensGas;
     const roi = (netGain / baseTokensSpent);
-    const apy = (1+roi)**(1/termRemainingYears) - 1;
+    const apr = (roi)*(1/termRemainingYears);
 
     // Change X% from X/100 to X
     return {
         estimatedRedemption: returnedTokens,
         netGain: netGain,
         roi: roi * 100,
-        apy: apy * 100
+        apr: apr * 100
     }
 }
 


### PR DESCRIPTION
Swap APY with APR in calculations and in gain display.

APY is misleading due to its expectation that the user would roll-over their terms.
APR being roi / termInYears.